### PR TITLE
Ad/drop down

### DIFF
--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -1,5 +1,5 @@
 class Pet < ApplicationRecord
-  validates_presence_of :image, :name, :age, :sex
+  validates_presence_of :image, :name, :age, :sex, :description
 
   belongs_to :shelter
   has_many :application_pets

--- a/app/views/pets/edit.html.erb
+++ b/app/views/pets/edit.html.erb
@@ -1,13 +1,13 @@
 <%= form_tag "/shelters/#{@pet.shelter.id}/pets/#{@pet.id}", method: :patch do %>
-  <%= label_tag :image %>
-  <%= text_field_tag :image, @pet.image %>
   <%= label_tag :name %>
-  <%= text_field_tag :name, @pet.name %>
-  <%= label_tag :description %>
-  <%= text_field_tag :description, @pet.description %>
+  <%= text_field_tag :name, @pet.name %> <br>
   <%= label_tag :age %>
-  <%= text_field_tag :age, @pet.age %>
+  <%= text_field_tag :age, @pet.age %> <br>
   <%= label_tag :sex %>
-  <%= text_field_tag :sex, @pet.sex %>
+  <%= select_tag :sex, options_for_select(['M', 'F'], @pet.sex) %><br>
+  <%= label_tag :description %>
+  <%= text_field_tag :description, @pet.description %> <br>
+  <%= label_tag :image %>
+  <%= text_field_tag :image, @pet.image %> <br> <br>
   <%= submit_tag "Update #{@pet.name}" %>
 <% end %>

--- a/app/views/pets/new.html.erb
+++ b/app/views/pets/new.html.erb
@@ -1,13 +1,13 @@
 <%= form_tag "/shelters/#{@shelter.id}/pets", method: :post do %>
-  <%= label_tag :image %>
-  <%= text_field_tag :image %>
   <%= label_tag :name %>
-  <%= text_field_tag :name %>
-  <%= label_tag :description %>
-  <%= text_field_tag :description %>
+  <%= text_field_tag :name %> <br>
   <%= label_tag :age %>
-  <%= text_field_tag :age %>
+  <%= text_field_tag :age %> <br>
   <%= label_tag :sex %>
-  <%= text_field_tag :sex %>
+  <%= select_tag :sex, options_for_select(['M', 'F']) %><br>
+  <%= label_tag :description %>
+  <%= text_field_tag :description %> <br>
+  <%= label_tag :image %>
+  <%= text_field_tag :image %> <br> <br>
   <%= submit_tag 'Create Pet' %>
 <% end %>

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -2,8 +2,8 @@
 
 <p><%= image_tag(@pet.image) %></p>
 <p>Age: <%= @pet.age %></p>
-<p>Description: <%= @pet.description %></p>
 <p>Sex: <%= @pet.sex %></p>
+<p>Description: <%= @pet.description %></p>
 <p>Availability: <%= @pet.adopted? %></p>
 <% if  @pet.adopted? == "Pending" %>
   <p> On hold for <%= "#{@pet.applications[0].name}" %> </p>

--- a/spec/features/pets/delete_spec.rb
+++ b/spec/features/pets/delete_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "As a visitor" do
       name: "Penny",
       age: 2,
       sex: "F",
+      description: "cute"
       )
 
     @shelter.pets << @penny

--- a/spec/features/pets/edit_spec.rb
+++ b/spec/features/pets/edit_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "As a visitor" do
       name: "Penny",
       age: 2,
       sex: "F",
+      description: "cute"
       )
 
     @shelter.pets << @penny
@@ -41,12 +42,12 @@ RSpec.describe "As a visitor" do
 
     fill_in :image, with: 'https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/12234558/Chinook-On-White-03.jpg'
     fill_in :name, with: "Peewee"
-    fill_in :description, with: "Lively pup"
+    fill_in :description, with: ""
     fill_in :age, with: ""
-    fill_in :sex, with: ""
+    select 'F', :from => :sex
 
     click_button "Update #{@penny.name}"
-    expect(page).to have_content("Age can't be blank and Sex can't be blank")
+    expect(page).to have_content("Age can't be blank and Description can't be blank")
     expect(current_path).to eq("/shelters/#{@shelter.id}/pets/#{@penny.id}/edit")
   end
 end

--- a/spec/features/pets/index_spec.rb
+++ b/spec/features/pets/index_spec.rb
@@ -15,12 +15,14 @@ RSpec.describe "As a visitor" do
       name: "Penny",
       age: 2,
       sex: "F",
+      description: "huge"
       )
     @paulie = Pet.create(
       image: 'https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/12234558/Chinook-On-White-03.jpg',
       name: "Paulie",
       age: 3,
       sex: "F",
+      description: "huge"
       )
 
     @shelter.pets << [@penny, @paulie]
@@ -68,12 +70,14 @@ RSpec.describe "As a visitor" do
       name: "Penny",
       age: 2,
       sex: "F",
+      description: "huge"
       )
     @paulie = Pet.create(
       image: 'https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/12234558/Chinook-On-White-03.jpg',
       name: "Paulie",
       age: 3,
       sex: "F",
+      description: "huge"
       )
 
     @shelter.pets << [@penny, @paulie]

--- a/spec/features/pets/new_spec.rb
+++ b/spec/features/pets/new_spec.rb
@@ -10,14 +10,6 @@ RSpec.describe "As a visitor" do
       zip: "80210"
       )
 
-    @penny = Pet.create(
-      image: 'https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/12234558/Chinook-On-White-03.jpg',
-      name: "Penny",
-      age: 2,
-      sex: "F",
-      )
-    @shelter.pets << @penny
-
     visit "/shelters/#{@shelter.id}/pets"
   end
 
@@ -30,14 +22,14 @@ RSpec.describe "As a visitor" do
     fill_in :name, with: "Peewee"
     fill_in :description, with: "Lively pup"
     fill_in :age, with: 3
-    fill_in :sex, with: "Female"
+    select 'F', :from => :sex
 
     click_button "Create Pet"
     expect(current_path).to eq("/shelters/#{@shelter.id}/pets")
     expect(page).to have_content("Peewee")
     expect(page).to have_content("Lively pup")
     expect(page).to have_content(3)
-    expect(page).to have_content("Female")
+    expect(page).to have_content("F")
   end
 
   it "shows flash message if new pet form is filled out incorrectly" do
@@ -47,12 +39,12 @@ RSpec.describe "As a visitor" do
 
     fill_in :image, with: 'https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/12234558/Chinook-On-White-03.jpg'
     fill_in :name, with: "Peewee"
-    fill_in :description, with: "Lively pup"
+    fill_in :description, with: ""
     fill_in :age, with: ""
-    fill_in :sex, with: ""
+    select 'F', :from => :sex
 
     click_button "Create Pet"
-    expect(page).to have_content("Age can't be blank and Sex can't be blank")
+    expect(page).to have_content("Age can't be blank and Description can't be blank")
     expect(current_path).to eq("/shelters/#{@shelter.id}/pets/new")
   end
 end


### PR DESCRIPTION
- Added a drop down menu for the `sex` attribute of `pets` on the `new` and `edit` view pages.
- Changed the test to account for the presence of the drop down menu
- Made the `pet` model validate the presence of the `description` field upon creation
- Changed the tests to account for the `description` field